### PR TITLE
Added support for "disable: 'if-port-is-already-open'"

### DIFF
--- a/lib/selenium-sauce.js
+++ b/lib/selenium-sauce.js
@@ -5,6 +5,8 @@ var webdriverio = require('webdriverio'),
     sauceConnectLauncher = require('sauce-connect-launcher'),
     extend = require('extend'),
     colors = require('colors'),
+    async = require('async'),
+    portscanner = require('portscanner'),
     SauceLabs = require('saucelabs');
 
 /**
@@ -128,54 +130,102 @@ extend(SeSauce.prototype, {
 
         this.webdriver = webdriverio;
 
-        if (!this.options.httpServer.disable) {
-            this._log("Launching local web server (http://localhost:" + this.options.httpServer.port + "/)...");
-            this.httpServer = httpserver.createServer(this.options.httpServer);
-            this.httpServer.listen(this.options.httpServer.port);
-            this._log("Web server ready.");
-        }
-
-        if (this.options.sauceLabs.username && this.options.sauceLabs.password) {
-            this._log("Initializing SauceLabs API.");
-            this.sauceLabs = new SauceLabs({
-                username: this.options.sauceLabs.username,
-                password: this.options.sauceLabs.password
-            });
-        }
-
-        if (this.options.sauceConnect.username && this.options.sauceConnect.accessKey) {
-            if (this.options.sauceConnect.disable)
-                this._log("Sauce Connect disabled.");
-            else {
-                this._log("Launching Sauce Connect...");
-                sauceConnectLauncher(this.options.sauceConnect, function (errmsg, process) {
-                    if (errmsg) {
-                        if (process) process.close();
-                        return self._doError('Error launching Sauce Connect:\n' + errmsg, complete);
-                    }
-                    self.sauceConnect = process;
-                    self._log("Sauce Connect ready.");
-                    complete();
-                });
-            }
-        }
-        else {
-            this._log("No SauceLabs username/accessKey. Launching Selenium locally...");
-
-            this.selenium = selenium({stdio: 'pipe'}, this.options.selenium.args);
-
-            this.selenium.stderr.on('data', function (output) {
-                if (output.toString().indexOf('Started org.openqa.jetty.jetty.Server') != -1) {
-                    clearTimeout(self._localSeleniumLaunchTimer);
-                    self._log("Local Selenium server launched.");
-                    complete();
+        async.parallel([
+            function (cb) {
+                function launchHttpServer() {
+                    self._log("Launching local web server (http://localhost:" + self.options.httpServer.port + "/)...");
+                    self.httpServer = httpserver.createServer(self.options.httpServer);
+                    self.httpServer.listen(self.options.httpServer.port, function () {
+                        self._log("Web server ready.");
+                        cb();
+                    });
                 }
-            });
-
-            this._localSeleniumLaunchTimer = setTimeout(function () {
-                self._doError('Selenium web driver timed out while trying to connect to local Selenium server.', complete);
-            }, 5000);
-        }
+                if (self.options.httpServer.disable) {
+                    if (self.options.httpServer.disable === 'if-port-is-already-open') {
+                        var httpServerPort = self.options.httpServer.port || 8080;
+                        portscanner.checkPortStatus(httpServerPort, 'localhost',
+                            function (err, status) {
+                                if (status === 'open') {
+                                    self._log("Port " + httpServerPort + " is already open. Skipping web server launch.");
+                                    cb();
+                                }
+                                else {
+                                    launchHttpServer();
+                                }
+                            });
+                    }
+                    else {
+                        cb();
+                    }
+                }
+                else {
+                    launchHttpServer();
+                }
+            },
+            function (cb) {
+                if (self.options.sauceLabs.username && self.options.sauceLabs.password) {
+                    self._log("Initializing SauceLabs API.");
+                    self.sauceLabs = new SauceLabs({
+                        username: self.options.sauceLabs.username,
+                        password: self.options.sauceLabs.password
+                    });
+                }
+                if (self.options.sauceConnect.username && self.options.sauceConnect.accessKey) {
+                    if (self.options.sauceConnect.disable) {
+                        self._log("Sauce Connect disabled.");
+                        cb();
+                    }
+                    else {
+                        self._log("Launching Sauce Connect...");
+                        sauceConnectLauncher(self.options.sauceConnect, function (errmsg, process) {
+                            if (errmsg) {
+                                if (process) process.close();
+                                return self._doError('Error launching Sauce Connect:\n' + errmsg, cb);
+                            }
+                            self.sauceConnect = process;
+                            self._log("Sauce Connect ready.");
+                            cb();
+                        });
+                    }
+                }
+                else {
+                    function launchSelenium() {
+                        self._log("No SauceLabs username/accessKey. Launching Selenium locally...");
+                        self.selenium = selenium({stdio: 'pipe'}, self.options.selenium.args);
+                        self.selenium.stderr.on('data', function (output) {
+                            if (output.toString().indexOf('Started org.openqa.jetty.jetty.Server') != -1) {
+                                clearTimeout(self._localSeleniumLaunchTimer);
+                                self._log("Local Selenium server launched.");
+                                cb();
+                            }
+                        });
+                        self._localSeleniumLaunchTimer = setTimeout(function () {
+                            self._doError('Selenium web driver timed out while trying to connect to local Selenium server.', cb);
+                        }, 5000);
+                    }
+                    if (self.options.selenium.disable) {
+                        if (self.options.selenium.disable === 'if-port-is-already-open') {
+                            var seleniumPort = self.options.webdriver.port || 4444;
+                            portscanner.checkPortStatus(seleniumPort, 'localhost',
+                                function (err, status) {
+                                    if (status === 'open') {
+                                        self._log("Port " + seleniumPort + " is already open. Skipping Selenium launch.");
+                                        cb();
+                                    }
+                                    else {
+                                        launchSelenium();
+                                    }
+                                });
+                        } else {
+                            cb();
+                        }
+                    }
+                    else {
+                        launchSelenium();
+                    }
+                }
+            }],
+            complete);
     },
 
     /**

--- a/package.json
+++ b/package.json
@@ -28,6 +28,8 @@
         "colors": "^1.0.3",
         "extend": "^2.0.0",
         "http-server": "^0.7.2",
+        "async": "^0.9.0",
+        "portscanner": "^1.0.0",
         "sauce-connect-launcher": "^0.9.0",
         "saucelabs": "^0.1.1",
         "selenium-standalone": "2.43.1-5",


### PR DESCRIPTION
Hello Alex,

as you already know PR introduces 'if-port-is-already-open' as a possible value for httpServer.disable/selenium.disable options. Please note that it's missing sauceConnect.disable (Sauce Connect listens on port 4445 be default). I would have added it myself by I decided to opt for another solution in order to be able to run tests in parallel (strkio/strkio.github.io@449e8589a11f60496a4ef3a3029d5bed8d718867).

Anyway, thanks a lot for the project. It's been immensely helpful.
