### PR TITLE
feat(saucelabs): Hide SauceLabs key from logs

### DIFF
--- a/lib/selenium-sauce.js
+++ b/lib/selenium-sauce.js
@@ -226,7 +226,7 @@ extend(SeSauce.prototype, {
                         else {
                             self._log("Launching Sauce Connect...");
                             self._log("Username: " + self.options.sauceConnect.username);
-                            self._log("Access Key: " + self.options.sauceConnect.accessKey);
+                            self._log("Access Key: " + self.options.sauceConnect.accessKey.replace(/.(?=.{4,})/g, '*'));
                             delete self.options.sauceConnect.disable;
                             sauceConnectLauncher(self.options.sauceConnect, function (errmsg, process) {
                                 if (errmsg) {
@@ -285,7 +285,6 @@ extend(SeSauce.prototype, {
             complete
         );
     },
-
     /**
      * Logs an error message, stops all services, and then calls the 'complete' callback, passing in the error message.
      * @private


### PR DESCRIPTION
Hey @alexbrombal awesome package,

I've made a small PR for a change I found convenient for my usage.

Using `selenium-sauce` logs the saucelabs keys, which are private. This is particularly problematic
when running on CI for public projects. These changes mask part of the key so that the log looks
like the following:

'ABCD-EFGH-1234' -> '**********1234'

You can see an example of the output here: https://circleci.com/gh/obartra/ssim/322 as part of the `npm run test:web` task.